### PR TITLE
Obtain a refresh token for GD

### DIFF
--- a/oauthutil/oauthutil.go
+++ b/oauthutil/oauthutil.go
@@ -312,7 +312,7 @@ func Config(id, name string, config *oauth2.Config) error {
 		return err
 	}
 	state := fmt.Sprintf("%x", stateBytes)
-	authURL := config.AuthCodeURL(state)
+	authURL := config.AuthCodeURL(state, oauth2.AccessTypeOffline)
 
 	// Prepare webserver
 	server := authServer{


### PR DESCRIPTION
Note that modified this code to work temporarily to obtain a refresh_token with GD but do not know the implications with any other supported integrations with rclone.

Initially when connecting with GCD with your own `client_id` and `client_secret` rclone does not request `access_type=offline` with Google which does not return a `refresh_token` that is needed to keep a fresh `access_token`. Therefore subsequent requests with rclone does not work due to the `access_token` being expired.

The change enables the `AuthCodeURL` function to request the offline token and therefore receiving a refresh token.

There's also a workaround to get this working without changing the code if you know oauth2 well. You can modify the AuthCodeURL and provide the query parameter manually and rclone will pick up the necessary refresh_token.